### PR TITLE
Sure, here is the plan:

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,11 +48,11 @@
 <body class="bg-slate-50">
 
     <div id="app-container" class="container mx-auto max-w-4xl p-4 sm:p-6 pb-20">
-        
+
         <div id="user-view" class="no-print">
             <div id="form-container">
                 <header class="text-center mb-8"><h1 class="font-brand text-5xl text-blue-600">Delícias Urbanas</h1><p class="mt-2 text-md text-gray-500">O seu cardápio da semana está servido!</p></header>
-                
+
                 <div class="bg-white rounded-xl shadow-sm p-6 mb-6">
                     <h2 class="block text-lg font-semibold text-gray-800 mb-2">👤 1. Identificação</h2>
                     <div class="grid sm:grid-cols-2 gap-4">
@@ -82,7 +82,7 @@
             <div class="mb-8">
                 <button id="switchToUserFromAdmin" class="text-sm text-gray-500 hover:text-blue-600">⬅️ Voltar para o Cardápio (Visão Usuário)</button>
             </div>
-            
+
             <section id="order-status-section" class="bg-white rounded-xl shadow-sm p-6 mb-8">
                 <h2 class="text-2xl font-semibold text-gray-700 mb-4">📊 Status de Pedidos da Semana</h2>
                 <div id="order-status-container" class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -143,12 +143,12 @@
 
     <div id="print-report"></div>
     <div id="app-toast"></div>
-    
+
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-        import { getFirestore, collection, addDoc, onSnapshot, serverTimestamp, query, orderBy, doc, getDoc, setDoc, deleteDoc, updateDoc, getDocs } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getFirestore, collection, addDoc, onSnapshot, serverTimestamp, query, orderBy, doc, getDoc, setDoc, deleteDoc, updateDoc, getDocs, where } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js"; // Added where
         import { getAuth, signInWithEmailAndPassword, signOut, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-        
+
         const firebaseConfig = {
             apiKey: "AIzaSyDa24jUk24wjlMsJUC4uXwnbmxM4vCtocI",
             authDomain: "cardapio-8ddea.firebaseapp.com",
@@ -160,20 +160,22 @@
         const app = initializeApp(firebaseConfig);
         const db = getFirestore(app);
         const auth = getAuth(app);
+        let currentUserIsAdmin = false;
+        let currentMenuTimestamp = null; // For storing the loaded menu's timestamp
 
         const APP_CONFIG = {
             ADMIN_UID: 'LqAXao4FuOQAvzS3uQAd9et6OnK2',
         };
-        
+
         const menuDocRef = doc(db, "cardapio", "semanal");
         const pedidosCollectionRef = collection(db, "pedidosDaSemana");
         const funcionariosCollectionRef = collection(db, "funcionarios");
-        
+
         const fixedOptions = [{ name: 'Omelete', emoji: '🍳' }, { name: 'Filé de frango', emoji: '🍗' }];
         let weeklyMenu = [];
         let allOrders = [];
         let tempOrderData = {};
-        
+
         function getDayId(dayName) { return dayName.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-zA-Z]/g, "").toLowerCase(); }
 
         function showToast(message, type = 'info', duration = 3000) {
@@ -184,18 +186,18 @@
             toast.classList.add(type);
             setTimeout(() => { toast.className = toast.className.replace('show', ''); }, duration);
         }
-        
+
         function showCustomConfirm(message, onConfirm) {
             const modal = document.getElementById('custom-confirm-modal');
             const messageEl = document.getElementById('custom-confirm-message');
             const okBtn = document.getElementById('custom-confirm-ok-btn');
-            
+
             messageEl.textContent = message;
             modal.classList.remove('hidden');
 
             const newOkBtn = okBtn.cloneNode(true);
             okBtn.parentNode.replaceChild(newOkBtn, okBtn);
-            
+
             newOkBtn.addEventListener('click', () => {
                 onConfirm();
                 modal.classList.add('hidden');
@@ -261,7 +263,7 @@
                 }
             });
         }
-        
+
         function openEmployeeEditModal(rgf, nome) {
             document.getElementById('editEmployeeRGF').value = rgf;
             document.getElementById('editEmployeeName').value = nome;
@@ -283,10 +285,15 @@
                 showToast("Falha ao salvar as alterações do funcionário.", 'error');
             }
         }
-        
-        async function findEmployeeByRGF(rgf) {
+
+        async function findEmployeeByRGF(rgf) { // Made async
             const nameInput = document.getElementById('employeeName');
-            if (!rgf) { nameInput.value = ''; nameInput.placeholder = 'Preenchido automaticamente'; validateForm(); return; }
+            if (!rgf) {
+                nameInput.value = '';
+                nameInput.placeholder = 'Preenchido automaticamente';
+                await validateForm(); // await validateForm call
+                return;
+            }
             try {
                 const docSnap = await getDoc(doc(db, "funcionarios", rgf));
                 if (docSnap.exists()) {
@@ -294,34 +301,108 @@
                 } else {
                     nameInput.value = ''; nameInput.placeholder = 'RGF não encontrado';
                 }
-                validateForm();
+                await validateForm(); // await validateForm call
             } catch (error) {
                 console.error("Erro ao buscar funcionário:", error);
                 nameInput.value = ''; nameInput.placeholder = 'Erro na busca';
                 showToast("Erro ao buscar funcionário.", 'error');
+                await validateForm(); // ensure validation runs even on error
             }
         }
-        
+
         function createFallbackMenu() {
             const days = ['Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira'];
             return days.map(day => ({ day, isHoliday: false, isSpecial: false, pratoPrincipal: { name: 'Cardápio não definido', emoji: '🚧' }, opcao: { name: '', emoji: '' }, guarnicao: { name: 'A definir', emoji: '' } }));
         }
 
-        function loadAndDisplayMenu() {
-            onSnapshot(menuDocRef, (docSnap) => {
-                weeklyMenu = (docSnap.exists() && docSnap.data().menu?.length > 0) ? docSnap.data().menu : createFallbackMenu();
-                createMenuHTML();
-                renderOrdersTable(allOrders); 
+        function getMenuContext(menuData) {
+            // console.log("getMenuContext called with data:", menuData); // Keep for debugging if needed
+            if (currentUserIsAdmin) {
+                return 'ADMIN_EDIT';
+            }
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+
+            const currentDayOfWeek = today.getDay();
+
+            let lastUpdatedTimestampValue = menuData?.menuLastUpdated; // Can be Firestore Timestamp or null
+
+            if (!lastUpdatedTimestampValue) {
+                // console.log("No menuLastUpdated found, returning VIEW_ONLY_PREVIOUS");
+                return 'VIEW_ONLY_PREVIOUS';
+            }
+
+            // Ensure it's a JS Date object for comparison
+            const lastUpdatedDate = lastUpdatedTimestampValue.toDate ? lastUpdatedTimestampValue.toDate() : new Date(0); // Fallback to epoch if not a Timestamp
+            lastUpdatedDate.setHours(0, 0, 0, 0);
+
+            let lastThursday = new Date(today);
+            lastThursday.setDate(today.getDate() - (currentDayOfWeek - 4 + 7) % 7);
+            lastThursday.setHours(0, 0, 0, 0);
+
+            // console.log("Dates for context:", { today, lastUpdatedDate, lastThursday, currentDayOfWeek });
+
+            if (lastUpdatedDate >= lastThursday) {
+                // console.log("Menu updated on or after last Thursday, returning EDITABLE_CURRENT");
+                return 'EDITABLE_CURRENT';
+            } else {
+                // console.log("Menu updated before last Thursday, returning VIEW_ONLY_PREVIOUS");
+                return 'VIEW_ONLY_PREVIOUS';
+            }
+        }
+
+        async function checkIfOrderExists(rgf, menuTimestamp) {
+            if (!rgf || !menuTimestamp) {
+                console.log("checkIfOrderExists: RGF or menuTimestamp missing", {rgf, menuTimestamp});
+                return false;
+            }
+            const q = query(pedidosCollectionRef, where("employeeRGF", "==", rgf), where("menuTimestamp", "==", menuTimestamp));
+            try {
+                const querySnapshot = await getDocs(q);
+                console.log(`checkIfOrderExists: RGF=${rgf}, Found=${!querySnapshot.empty}, Orders checked=${querySnapshot.size}`);
+                return !querySnapshot.empty;
+            } catch (error) {
+                console.error("Error in checkIfOrderExists: ", error);
+                showToast("Erro ao verificar pedidos existentes.", "error");
+                return false; // Fail safe
+            }
+        }
+
+
+        async function loadAndDisplayMenu() {
+            onSnapshot(menuDocRef, async (docSnap) => { // made callback async
+                const menuData = docSnap.exists() ? docSnap.data() : { menu: [] };
+                weeklyMenu = (menuData.menu?.length > 0) ? menuData.menu : createFallbackMenu();
+                currentMenuTimestamp = docSnap.exists() ? (menuData.menuLastUpdated || null) : null; // Store timestamp
+
+                const menuContext = getMenuContext(menuData);
+                let orderExistsForContext = false;
+
+                if (menuContext === 'EDITABLE_CURRENT' && !currentUserIsAdmin) {
+                    const rgf = document.getElementById('employeeRGF')?.value.trim();
+                    if (rgf && currentMenuTimestamp) {
+                        orderExistsForContext = await checkIfOrderExists(rgf, currentMenuTimestamp);
+                    }
+                }
+
+                createMenuHTML(menuContext, orderExistsForContext);
+                renderOrdersTable(allOrders, menuContext);
+                await validateForm();
             }, (error) => {
                  console.error("Erro ao carregar o cardápio:", error);
                  showToast("Erro ao carregar o cardápio. Usando cardápio padrão.", 'error');
                  weeklyMenu = createFallbackMenu();
-                 createMenuHTML();
-                 renderOrdersTable(allOrders);
+                 currentMenuTimestamp = null;
+                 const menuContext = getMenuContext({ menu: weeklyMenu });
+                 createMenuHTML(menuContext, false);
+                 renderOrdersTable(allOrders, menuContext);
+                 validateForm();
             });
         }
-        
-        function createMenuHTML() {
+
+        function createMenuHTML(menuContext, orderExists = false) {
+            console.log("createMenuHTML Context:", menuContext, "Order Exists:", orderExists);
             const menuContainer = document.getElementById('menu');
             if (!menuContainer) return;
             menuContainer.innerHTML = '';
@@ -329,7 +410,7 @@
             weeklyMenu.forEach(item => {
                 const dayId = getDayId(item.day);
                 let dayHTML = `<div class="day-section space-y-3">`;
-                
+
                 let dayTitleHTML = `<h3 class="text-xl font-bold text-gray-800">${item.day}</h3>`;
                 if (item.isSpecial) {
                     dayTitleHTML = `<div class="flex items-center gap-3">
@@ -337,7 +418,7 @@
                         <span class="text-sm font-semibold text-purple-800 bg-purple-200 rounded-full px-3 py-1">✨ Almoço Especial</span>
                     </div>`;
                 }
-                
+
                 if (item.isHoliday) {
                     dayHTML += dayTitleHTML;
                     dayHTML += `
@@ -346,6 +427,17 @@
                             <p>Não haverá refeição neste dia.</p>
                         </div>`;
                 } else {
+                    let isEditable = true;
+                    if (menuContext === 'ADMIN_EDIT') {
+                        isEditable = true;
+                    } else if (menuContext === 'VIEW_ONLY_PREVIOUS') {
+                        isEditable = false;
+                    } else if (menuContext === 'EDITABLE_CURRENT') {
+                        isEditable = !orderExists;
+                    } else {
+                        isEditable = false;
+                    }
+
                     const allOptions = [
                         { ...item.pratoPrincipal, type: 'Prato Principal' },
                         ...(item.opcao?.name ? [{ ...item.opcao, type: 'Opção do Dia' }] : []),
@@ -356,12 +448,12 @@
                     if (item.guarnicao?.name) {
                         dayHTML += `<div class="text-sm font-semibold text-blue-600 bg-blue-100 rounded-full inline-block px-3 py-1 mb-3">Guarnição: ${item.guarnicao.name} ${item.guarnicao.emoji || ''}</div>`;
                     }
-                    
+
                     dayHTML += `<div class="space-y-3">`;
                     allOptions.forEach((option) => {
                         if (option.name) {
-                            dayHTML += `<label class="menu-option-card block p-4 border-2 border-gray-200 rounded-lg cursor-pointer transition-transform duration-200">
-                                <input type="radio" name="${dayId}" value="${option.name}" class="hidden">
+                            dayHTML += `<label class="menu-option-card block p-4 border-2 border-gray-200 rounded-lg transition-transform duration-200 ${!isEditable ? 'opacity-75 cursor-not-allowed' : 'cursor-pointer'}">
+                                <input type="radio" name="${dayId}" value="${option.name}" class="hidden" ${!isEditable ? 'disabled' : ''}>
                                 <div class="flex items-center">
                                     <span class="text-3xl mr-4">${option.emoji || '🍽️'}</span>
                                     <div class="flex-grow">
@@ -374,61 +466,93 @@
                         }
                     });
                     dayHTML += `</div>`;
-                    
+
                     dayHTML += `<div class="mt-3">
-                        <textarea id="notes-${dayId}" name="notes-${dayId}" rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="Anotações? Ex: sem cebola, ponto da carne, etc."></textarea>
+                        <textarea id="notes-${dayId}" name="notes-${dayId}" rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="Anotações? Ex: sem cebola, ponto da carne, etc." ${!isEditable ? 'readonly' : ''}></textarea>
                     </div>`;
                 }
 
                 dayHTML += `</div>`;
                 menuContainer.innerHTML += dayHTML;
             });
-
-            validateForm();
         }
 
-        function validateForm() {
-            const name = document.getElementById('employeeName')?.value.trim();
+        async function validateForm() {
             const rgf = document.getElementById('employeeRGF')?.value.trim();
+            const name = document.getElementById('employeeName')?.value.trim();
             const guidanceSection = document.getElementById('guidanceSection');
             const guidanceText = document.getElementById('guidanceText');
             const submitBtnContainer = document.getElementById('submitButtonContainer');
+
             if (!guidanceSection || !submitBtnContainer) return;
 
-            const nonHolidayItems = weeklyMenu.filter(item => !item.isHoliday);
-            const hasAllSelections = nonHolidayItems.length > 0 && nonHolidayItems.every(item => document.querySelector(`input[name="${getDayId(item.day)}"]:checked`));
+            const menuDocSnap = await getDoc(menuDocRef);
+            const menuData = menuDocSnap.exists() ? menuDocSnap.data() : {};
+            const menuContext = getMenuContext(menuData);
 
-            if (name && rgf && hasAllSelections) {
+            let orderExists = false;
+            if (menuContext === 'EDITABLE_CURRENT' && rgf && currentMenuTimestamp && !currentUserIsAdmin) {
+                orderExists = await checkIfOrderExists(rgf, currentMenuTimestamp);
+            }
+
+            guidanceSection.classList.remove('hidden');
+            submitBtnContainer.classList.add('hidden');
+
+            if (menuContext === 'ADMIN_EDIT') {
                 guidanceSection.classList.add('hidden');
-                submitBtnContainer.classList.remove('hidden');
-            } else {
-                submitBtnContainer.classList.add('hidden');
-                guidanceSection.classList.remove('hidden');
-                let message = '';
-                if(!rgf) message = 'Digite seu RGF para começar. ';
-                else if(!name) message = 'RGF não encontrado. Peça para um administrador cadastrá-lo. ';
-                else if (!hasAllSelections) {
-                    const missingDays = nonHolidayItems
-                        .filter(item => !document.querySelector(`input[name="${getDayId(item.day)}"]:checked`))
-                        .map(item => item.day);
-                    if (missingDays.length > 0) message += `Falta selecionar opções para: ${missingDays.join(', ')}.`;
+            } else if (menuContext === 'VIEW_ONLY_PREVIOUS') {
+                guidanceText.textContent = 'Este é um cardápio anterior e está disponível apenas para visualização.';
+            } else if (!rgf) {
+                guidanceText.textContent = 'Digite seu RGF para começar.';
+            } else if (!name) {
+                guidanceText.textContent = 'RGF não encontrado. Peça para um administrador cadastrá-lo.';
+            } else if (menuContext === 'EDITABLE_CURRENT') {
+                if (orderExists) {
+                    guidanceText.textContent = 'Você já enviou seu pedido para o cardápio desta semana.';
+                } else {
+                    const nonHolidayItems = weeklyMenu.filter(item => !item.isHoliday);
+                    const hasAllSelections = nonHolidayItems.length > 0 && nonHolidayItems.every(item =>
+                        document.querySelector(`input[name="${getDayId(item.day)}"]:checked`)
+                    );
+
+                    if (hasAllSelections) {
+                        guidanceSection.classList.add('hidden');
+                        submitBtnContainer.classList.remove('hidden');
+                    } else {
+                        const missingDays = nonHolidayItems
+                            .filter(item => !document.querySelector(`input[name="${getDayId(item.day)}"]:checked`))
+                            .map(item => item.day);
+                        if (missingDays.length > 0) {
+                            guidanceText.textContent = `Falta selecionar opções para: ${missingDays.join(', ')}.`;
+                        } else if (nonHolidayItems.length === 0 && weeklyMenu.length > 0) {
+                             guidanceText.textContent = 'Não há dias disponíveis para pedido nesta semana.';
+                        } else if (nonHolidayItems.length === 0) {
+                             guidanceText.textContent = 'Cardápio ainda não disponível ou sem itens para pedido.';
+                        }
+                        else {
+                            guidanceText.textContent = 'Complete seu pedido para continuar.';
+                        }
+                    }
                 }
-                guidanceText.textContent = message || 'Por favor, preencha todos os campos.';
+            } else {
+                guidanceText.textContent = 'O cardápio não está disponível para pedidos no momento.';
             }
         }
+
 
         function openConfirmationModal() {
             tempOrderData = {
                 employeeName: document.getElementById('employeeName').value.trim(),
                 employeeRGF: document.getElementById('employeeRGF').value.trim(),
-                timestamp: serverTimestamp()
+                timestamp: serverTimestamp(),
+                menuTimestamp: currentMenuTimestamp
             };
             const summaryContainer = document.getElementById('confirmation-summary');
             summaryContainer.innerHTML = '';
-            
+
             weeklyMenu.forEach(item => {
                 const dayId = getDayId(item.day);
-                
+
                 if (!item.isHoliday) {
                     const choiceInput = document.querySelector(`input[name="${dayId}"]:checked`);
                     if (!choiceInput) return;
@@ -443,13 +567,30 @@
                     summaryContainer.innerHTML += `<p><span class="font-bold">${item.day}:</span> ${choice} ${notes ? `<span class="text-sm text-gray-500 italic">(${notes})</span>` : ''}</p>`;
                 }
             });
-            
+
             document.getElementById('confirmation-modal').classList.remove('hidden');
         }
 
         async function submitOrder() {
             const button = document.getElementById('submitOrder');
             button.disabled = true; button.textContent = 'A enviar...';
+
+            if (Object.keys(tempOrderData).length === 0 || !tempOrderData.employeeRGF) {
+                 tempOrderData.employeeName = document.getElementById('employeeName').value.trim();
+                 tempOrderData.employeeRGF = document.getElementById('employeeRGF').value.trim();
+                 tempOrderData.timestamp = serverTimestamp();
+                 weeklyMenu.forEach(item => {
+                    if(!item.isHoliday) {
+                        const dayId = getDayId(item.day);
+                        const choiceInput = document.querySelector(`input[name="${dayId}"]:checked`);
+                        if(choiceInput) tempOrderData[dayId] = choiceInput.value;
+                        const notes = document.getElementById(`notes-${dayId}`).value.trim();
+                        if(notes) tempOrderData[`${dayId}_notes`] = notes;
+                    }
+                 });
+            }
+            tempOrderData.menuTimestamp = currentMenuTimestamp;
+
             try {
                 await addDoc(pedidosCollectionRef, tempOrderData);
                 document.getElementById('confirmation-modal').classList.add('hidden');
@@ -457,14 +598,16 @@
                 document.getElementById('success-text').textContent = `Obrigado, ${tempOrderData.employeeName}. O seu pedido foi registado com sucesso.`;
                 document.getElementById('success-message').classList.remove('hidden');
                 showToast("Pedido enviado com sucesso!", 'success');
+                await validateForm();
             } catch (error) {
                 console.error("Erro ao enviar pedido: ", error);
                 showToast("Ocorreu um erro ao enviar o seu pedido.", 'error');
             } finally {
                 button.disabled = false; button.textContent = 'Confirmar e Enviar';
+                tempOrderData = {};
             }
         }
-        
+
         function loadAdminData() {
             onSnapshot(pedidosCollectionRef, (snapshot) => {
                 const latestOrdersMap = new Map();
@@ -477,19 +620,29 @@
                          }
                     }
                 });
-                
+
                 allOrders = Array.from(latestOrdersMap.values())
                     .map(item => item.doc)
                     .sort((a, b) => a.data().employeeName.localeCompare(b.data().employeeName));
 
-                renderOrdersTable(allOrders);
-                renderOrderStatus(allOrders);
+                getDoc(menuDocRef).then(docSnap => {
+                    const menuData = docSnap.exists() ? docSnap.data() : { menu: [] };
+                    const menuContext = getMenuContext(menuData);
+                    renderOrdersTable(allOrders, menuContext);
+                    renderOrderStatus(allOrders);
+                }).catch(error => {
+                    console.error("Error getting menu for admin data rendering: ", error);
+                    const menuContext = getMenuContext({ menu: [] });
+                    renderOrdersTable(allOrders, menuContext);
+                    renderOrderStatus(allOrders);
+                });
+
             }, (error) => {
                 console.error("Erro ao carregar dados do administrador:", error);
                 showToast("Erro ao carregar dados do administrador.", 'error');
             });
         }
-        
+
         async function renderOrderStatus(orders) {
             const container = document.getElementById('order-status-container');
             container.innerHTML = '<p class="text-gray-500">A processar...</p>';
@@ -497,7 +650,7 @@
             try {
                 const employeeSnapshot = await getDocs(query(funcionariosCollectionRef, orderBy("nome")));
                 const allEmployees = employeeSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-                
+
                 const orderedRGFs = new Set(orders.map(orderDoc => orderDoc.data().employeeRGF));
 
                 const haveOrdered = allEmployees.filter(emp => orderedRGFs.has(emp.id));
@@ -520,15 +673,16 @@
                 container.innerHTML = '<p class="text-red-500">Falha ao carregar status dos funcionários.</p>';
             }
         }
-        
-        function renderOrdersTable(orders) {
+
+        function renderOrdersTable(orders, menuContext) {
+            // console.log("Render Orders Table Context:", menuContext);
             const container = document.getElementById('ordersTableContainer');
             const searchTerm = document.getElementById('searchInput').value.toLowerCase();
             const filteredOrders = orders.filter(doc => doc.data().employeeName.toLowerCase().includes(searchTerm));
 
             if (!weeklyMenu || weeklyMenu.length === 0) { container.innerHTML = '<p class="text-gray-500 text-center py-4">Aguardando cardápio...</p>'; return; }
             if (filteredOrders.length === 0) { container.innerHTML = '<p class="text-gray-500 text-center py-4">Nenhum pedido encontrado.</p>'; return; }
-            
+
             let tableHTML = `<table class="min-w-full bg-white border"><thead><tr class="bg-gray-50"><th class="py-2 px-3 border-b text-left">Funcionário</th><th class="py-2 px-3 border-b text-left">RGF</th>`;
             weeklyMenu.forEach(item => tableHTML += `<th class="py-2 px-3 border-b text-left">${item.day.substring(0,3)}</th>`);
             tableHTML += `<th class="py-2 px-3 border-b text-left">Ações</th></tr></thead><tbody>`;
@@ -554,7 +708,7 @@
                         } else if (optionDishName && choice === optionDishName) {
                             reportChoice = 'Opção';
                         }
-                        
+
                         cellContent = reportChoice;
                         if (notes) {
                             cellContent += ` <span title="${notes}" class="cursor-help text-blue-500 font-bold">*</span>`;
@@ -575,31 +729,31 @@
                 return;
             }
             reportContainer.innerHTML = '<h1>Regional Quatinga</h1>';
-            
+
             let allDaysHTML = '';
             weeklyMenu.forEach(dayMenuItem => {
-                if (dayMenuItem.isHoliday) return; 
+                if (dayMenuItem.isHoliday) return;
 
                 const dayId = getDayId(dayMenuItem.day);
                 let tableHTML = `<div class="report-day-section"><table class="report-table"><thead><tr><th class="rgf-col">RGF</th><th class="nome-col">NOME</th><th class="pedido-col">${dayMenuItem.day}</th></tr></thead><tbody>`;
-                
+
                 const dailyOrders = allOrders
                     .filter(orderDoc => orderDoc.data()[dayId])
                     .sort((a,b) => a.data().employeeName.localeCompare(b.data().employeeName));
-                
+
                 dailyOrders.forEach(orderDoc => {
                     const order = orderDoc.data();
                     const choice = order[dayId];
                     const notes = order[`${dayId}_notes`];
-                    
+
                     const mainDishName = dayMenuItem.pratoPrincipal.name;
                     const optionDishName = dayMenuItem.opcao?.name;
                     let reportChoice = '';
 
-                    if (choice === mainDishName) { reportChoice = 'PRATO'; } 
-                    else if (optionDishName && choice === optionDishName) { reportChoice = 'OPÇÃO'; } 
+                    if (choice === mainDishName) { reportChoice = 'PRATO'; }
+                    else if (optionDishName && choice === optionDishName) { reportChoice = 'OPÇÃO'; }
                     else { reportChoice = choice.toUpperCase(); }
-                    
+
                     let choiceHTML = reportChoice;
                     if (notes) { choiceHTML += ` <span style="font-style: italic; font-weight: normal;">(${notes})</span>`; }
 
@@ -618,6 +772,13 @@
             const employeeNameInput = document.getElementById('edit-order-employeeName');
             const orderIdInput = document.getElementById('edit-order-id');
 
+            // Determine if the current user is an admin for editing purposes
+            const menuDocSnap = await getDoc(menuDocRef);
+            const menuData = menuDocSnap.exists() ? menuDocSnap.data() : {};
+            const localMenuContext = getMenuContext(menuData); // Uses global currentUserIsAdmin
+            const isActuallyAdminEditing = localMenuContext === 'ADMIN_EDIT';
+            console.log("Admin Edit Modal - Context:", localMenuContext, "Is Admin Editing:", isActuallyAdminEditing);
+
             formContent.innerHTML = '<p class="text-center text-gray-500">A carregar...</p>';
             modal.classList.remove('hidden');
 
@@ -633,30 +794,33 @@
                 weeklyMenu.forEach(item => {
                     const dayId = getDayId(item.day);
                     let dayHTML = `<fieldset class="day-section border p-4 rounded-lg"><legend class="font-bold text-lg text-gray-800 px-2">${item.day}</legend>`;
-                    
+
                     if(item.isHoliday) {
                         dayHTML += `<div class="bg-indigo-100 text-indigo-700 p-3 rounded-md text-center">Feriado</div>`;
                     } else {
                         const currentChoice = orderData[dayId];
                         const currentNotes = orderData[`${dayId}_notes`] || '';
                         const allOptions = [ { ...item.pratoPrincipal }, ...(item.opcao?.name ? [{ ...item.opcao }] : []), ...fixedOptions ];
-                        
+
                         dayHTML += `<div class="space-y-2 mt-2">`;
                         allOptions.forEach((option, index) => {
                             if (option.name) {
                                 const uniqueId = `edit-${dayId}-${index}`;
                                 const isChecked = (option.name === currentChoice) ? 'checked' : '';
-                                dayHTML += `<div class="flex items-center"><input type="radio" id="${uniqueId}" name="${dayId}" value="${option.name}" class="h-4 w-4 text-blue-600 border-gray-300" ${isChecked} required><label for="${uniqueId}" class="ml-3 block text-sm font-medium text-gray-700">${option.emoji || ''} ${option.name}</label></div>`;
+                                dayHTML += `<div class="flex items-center">
+                                    <input type="radio" id="${uniqueId}" name="${dayId}" value="${option.name}" class="h-4 w-4 text-blue-600 border-gray-300" ${isChecked} required ${!isActuallyAdminEditing ? 'disabled' : ''}>
+                                    <label for="${uniqueId}" class="ml-3 block text-sm font-medium text-gray-700 ${!isActuallyAdminEditing ? 'cursor-not-allowed opacity-75' : ''}">${option.emoji || ''} ${option.name}</label>
+                                </div>`;
                             }
                         });
                         dayHTML += `</div>`;
-                        
+
                         dayHTML += `<div class="mt-4">
                             <label for="edit-notes-${dayId}" class="block text-sm font-medium text-gray-700">Anotações</label>
-                            <textarea id="edit-notes-${dayId}" name="edit-notes-${dayId}" rows="2" class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">${currentNotes}</textarea>
+                            <textarea id="edit-notes-${dayId}" name="edit-notes-${dayId}" rows="2" class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${!isActuallyAdminEditing ? 'readonly' : ''}>${currentNotes}</textarea>
                         </div>`;
                     }
-                    
+
                     dayHTML += `</fieldset>`;
                     formContent.innerHTML += dayHTML;
                 });
@@ -673,18 +837,21 @@
             button.disabled = true; button.textContent = 'A salvar...';
             const docId = document.getElementById('edit-order-id').value;
             const updateData = {};
-            
+
             weeklyMenu.forEach(item => {
                 if (!item.isHoliday) {
                     const dayId = getDayId(item.day);
                     const selectedOption = document.querySelector(`#edit-order-form input[name="${dayId}"]:checked`);
-                    if (selectedOption) { 
-                        updateData[dayId] = selectedOption.value; 
+                    if (selectedOption) {
+                        updateData[dayId] = selectedOption.value;
                     }
                     const notes = document.getElementById(`edit-notes-${dayId}`).value.trim();
                     updateData[`${dayId}_notes`] = notes;
                 }
             });
+            if (currentMenuTimestamp) {
+                updateData.menuTimestamp = currentMenuTimestamp;
+            }
 
             try {
                 await updateDoc(doc(db, "pedidosDaSemana", docId), updateData);
@@ -712,7 +879,7 @@
         }
 
         const toBase64 = file => new Promise((resolve, reject) => { const reader = new FileReader(); reader.readAsDataURL(file); reader.onload = () => resolve(reader.result.split(',')[1]); reader.onerror = error => reject(error); });
-        
+
         document.getElementById('imageUpload').addEventListener('change', function(event) {
             const file = event.target.files[0]; if (!file) return;
             const reader = new FileReader();
@@ -733,43 +900,43 @@
 
             const loader = document.getElementById('loader'); const button = document.getElementById('processImageBtn'); const confirmationForm = document.getElementById('confirmation-form');
             button.disabled = true; button.textContent = 'A analisar...'; loader.classList.remove('hidden'); confirmationForm.classList.add('hidden');
-            const file = document.getElementById('imageUpload').files[0]; 
+            const file = document.getElementById('imageUpload').files[0];
             const options = { maxSizeMB: 1.5, maxWidthOrHeight: 1500, useWebWorker: true };
             try {
                 const compressedFile = await imageCompression(file, options);
                 const base64ImageData = await toBase64(compressedFile);
-                
+
                 const prompt = `Analise a imagem deste cardápio semanal. Extraia as informações para cada dia (Segunda a Sexta). Para cada dia, identifique o 'Prato Principal', a 'Opção' e a 'Guarnição'. Se o dia for um feriado, marque-o. Além disso, determine se o almoço é 'especial' (ex: uma refeição comemorativa, temática ou de maior qualidade) e defina o campo booleano 'isSpecial'. Retorne um objeto JSON seguindo esta estrutura: {"menu": [{"day": "Segunda-feira", "isHoliday": false, "isSpecial": false, "pratoPrincipal": {"name": "Nome", "emoji": "🍛"}, "opcao": {"name": "Nome", "emoji": "🍲"}, "guarnicao": {"name": "Nome", "emoji": "🥗"}}, ...]}. Se um campo não existir, retorne o nome como string vazia. Atribua emojis apropriados. O JSON deve ser a única coisa na resposta.`;
 
                 const payload = { contents: [{ parts: [{ text: prompt }, { inline_data: { mime_type: compressedFile.type, data: base64ImageData } }] }] };
                 const apiKey = firebaseConfig.apiKey;
-                const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`; 
+                const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
 
                 const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
                 if (!response.ok) { const err = await response.json(); throw new Error(`API Error: ${err.error.message}`); }
                 const result = await response.json();
-                
+
                 let textResponse = result.candidates?.[0]?.content?.parts?.[0]?.text;
                 if (!textResponse) { throw new Error("Resposta da IA vazia ou mal formatada."); }
-                
+
                 textResponse = textResponse.replace(/```json/g, '').replace(/```/g, '').trim();
                 const menuData = JSON.parse(textResponse);
 
                 if (!menuData || !Array.isArray(menuData.menu)) { throw new Error("Estrutura do JSON da IA inváĺida."); }
-                
+
                 displayConfirmationForm(menuData.menu);
 
-            } catch (error) { 
-                console.error("Erro ao processar IA:", error); showToast("Erro ao ler imagem com IA: " + error.message, 'error', 8000); 
-            } finally { 
-                button.disabled = false; button.textContent = 'Analisar Cardápio'; loader.classList.add('hidden'); 
+            } catch (error) {
+                console.error("Erro ao processar IA:", error); showToast("Erro ao ler imagem com IA: " + error.message, 'error', 8000);
+            } finally {
+                button.disabled = false; button.textContent = 'Analisar Cardápio'; loader.classList.add('hidden');
             }
         });
 
         function displayConfirmationForm(menuData) {
-            const container = document.getElementById('confirmation-form'); 
+            const container = document.getElementById('confirmation-form');
             container.innerHTML = '<h3 class="text-xl font-semibold mb-4">Confirme os Dados Extraídos</h3>';
-            
+
             menuData.forEach((item, index) => {
                 container.innerHTML += `<div class="p-4 bg-gray-50 rounded-lg mb-4">
                     <h4 class="font-bold">${item.day}</h4>
@@ -785,8 +952,8 @@
                     </div>`;
             });
             container.innerHTML += `<div class="text-center mt-4"><button id="saveNewMenuBtn" class="w-full bg-green-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-600">Salvar Novo Cardápio</button><button type="button" id="cancelNewMenuBtn" class="w-full mt-2 bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg hover:bg-gray-400">Cancelar</button></div>`;
-            container.classList.remove('hidden'); 
-            
+            container.classList.remove('hidden');
+
             document.getElementById('saveNewMenuBtn').addEventListener('click', () => {
                 const message = "Tem certeza que deseja salvar o novo cardápio? TODOS os pedidos da semana anterior serão excluídos permanentemente. Esta ação não pode ser desfeita.";
                 showCustomConfirm(message, () => {
@@ -796,11 +963,11 @@
 
             document.getElementById('cancelNewMenuBtn').addEventListener('click', () => {
                 container.classList.add('hidden'); document.getElementById('imagePreview').classList.add('hidden');
-                document.getElementById('image-processor-container').classList.add('hidden'); document.getElementById('imageUpload').value = ''; 
+                document.getElementById('image-processor-container').classList.add('hidden'); document.getElementById('imageUpload').value = '';
                 showToast("Atualização cancelada.", 'info');
             });
         }
-        
+
         async function clearAllOrders() {
             console.log("Iniciando a limpeza de todos os pedidos da semana...");
             const querySnapshot = await getDocs(pedidosCollectionRef);
@@ -812,41 +979,41 @@
             console.log(`${deletionPromises.length} pedidos foram excluídos com sucesso.`);
         }
 
-        async function saveNewMenu(menuData) {
-            const button = document.getElementById('saveNewMenuBtn'); 
+        async function saveNewMenu(menuDataFromAI) {
+            const button = document.getElementById('saveNewMenuBtn');
             const cancelButton = document.getElementById('cancelNewMenuBtn');
             button.disabled = true;
             cancelButton.disabled = true;
-            button.textContent = 'A salvar...'; 
+            button.textContent = 'A salvar...';
 
-            const newMenu = menuData.map((item, i) => ({ 
-                day: item.day, 
-                pratoPrincipal: { name: document.getElementById(`prato-${i}`).value.trim(), emoji: '🍛' }, 
-                opcao: { name: document.getElementById(`opcao-${i}`).value.trim(), emoji: '🍲' }, 
+            const newMenu = menuDataFromAI.map((item, i) => ({
+                day: item.day,
+                pratoPrincipal: { name: document.getElementById(`prato-${i}`).value.trim(), emoji: '🍛' },
+                opcao: { name: document.getElementById(`opcao-${i}`).value.trim(), emoji: '🍲' },
                 guarnicao: { name: document.getElementById(`guarnicao-${i}`).value.trim(), emoji: '🥗' },
                 isHoliday: document.getElementById(`holiday-${i}`).checked,
                 isSpecial: document.getElementById(`special-${i}`).checked,
-            })); 
+            }));
 
-            try { 
-                await setDoc(menuDocRef, { menu: newMenu });
+            try {
+                await setDoc(menuDocRef, { menu: newMenu, menuLastUpdated: serverTimestamp() });
                 await clearAllOrders();
-                showToast('Cardápio atualizado e pedidos zerados!', 'success'); 
-                document.getElementById('confirmation-form').classList.add('hidden'); 
+                showToast('Cardápio atualizado e pedidos zerados!', 'success');
+                document.getElementById('confirmation-form').classList.add('hidden');
                 document.getElementById('imagePreview').classList.add('hidden');
-                document.getElementById('image-processor-container').classList.add('hidden'); 
-                document.getElementById('imageUpload').value = ''; 
+                document.getElementById('image-processor-container').classList.add('hidden');
+                document.getElementById('imageUpload').value = '';
                 document.getElementById('whatsapp-notification-container').classList.remove('hidden');
-            } catch (error) { 
-                console.error("Erro ao salvar o cardápio ou zerar pedidos:", error); 
-                showToast("Erro ao salvar o novo cardápio.", 'error'); 
-            } finally { 
-                button.disabled = false; 
+            } catch (error) {
+                console.error("Erro ao salvar o cardápio ou zerar pedidos:", error);
+                showToast("Erro ao salvar o novo cardápio.", 'error');
+            } finally {
+                button.disabled = false;
                 cancelButton.disabled = false;
-                button.textContent = 'Salvar Novo Cardápio'; 
+                button.textContent = 'Salvar Novo Cardápio';
             }
         }
-        
+
         function handleWhatsAppNotification() {
             const message = `O cardápio da semana foi atualizado! ✨ Confira as delícias e faça seu pedido: ${window.location.href}`;
             const encodedMessage = encodeURIComponent(message);
@@ -856,7 +1023,9 @@
         }
 
         onAuthStateChanged(auth, (user) => {
-            if (user && user.uid === APP_CONFIG.ADMIN_UID) {
+            currentUserIsAdmin = (user && user.uid === APP_CONFIG.ADMIN_UID);
+
+            if (currentUserIsAdmin) {
                 showAdminView();
             } else {
                 if (!auth.currentUser) {
@@ -873,14 +1042,14 @@
             document.getElementById('user-view').classList.remove('hidden');
             document.getElementById('admin-view').classList.add('hidden');
             document.getElementById('admin-login-modal').classList.add('hidden');
-            loadAndDisplayMenu(); 
+            loadAndDisplayMenu();
         }
 
         function showAdminView() {
             document.getElementById('user-view').classList.add('hidden');
             document.getElementById('admin-view').classList.remove('hidden');
             document.getElementById('admin-login-modal').classList.add('hidden');
-            loadAndDisplayMenu(); 
+            loadAndDisplayMenu();
             loadAdminData();
             loadAndRenderEmployees();
         }
@@ -907,48 +1076,62 @@
         }
 
         async function handleAdminLogout() {
-            try { await signOut(auth); showToast("Logout de administrador bem-sucedido!", 'info'); } 
+            try {
+                await signOut(auth);
+                showToast("Logout de administrador bem-sucedido!", 'info');
+            }
             catch (error) { console.error("Erro no logout:", error); showToast("Erro ao fazer logout.", 'error'); }
         }
 
-        function main() {
+        async function main() {
             const rgfInput = document.getElementById('employeeRGF');
             rgfInput.value = localStorage.getItem('employeeRGF') || '';
-            if(rgfInput.value) { findEmployeeByRGF(rgfInput.value); }
-            rgfInput.addEventListener('blur', (e) => { localStorage.setItem('employeeRGF', e.target.value); findEmployeeByRGF(e.target.value); });
-            rgfInput.addEventListener('input', validateForm);
-            
-            document.getElementById('menu').addEventListener('change', validateForm);
+            if(rgfInput.value) { await findEmployeeByRGF(rgfInput.value); }
+
+            rgfInput.addEventListener('blur', async (e) => {
+                localStorage.setItem('employeeRGF', e.target.value);
+                await findEmployeeByRGF(e.target.value);
+            });
+            rgfInput.addEventListener('input', async () => { await validateForm(); });
+
+            document.getElementById('menu').addEventListener('change', async () => { await validateForm(); });
             document.getElementById('openConfirmationModal').addEventListener('click', openConfirmationModal);
             document.getElementById('submitOrder').addEventListener('click', submitOrder);
-            
+
             document.querySelectorAll('.cancel-modal-btn, #custom-confirm-cancel-btn').forEach(btn => {
                 btn.addEventListener('click', () => btn.closest('.modal-overlay').classList.add('hidden'));
             });
 
             document.getElementById('switchToAdmin').addEventListener('click', () => document.getElementById('admin-login-modal').classList.remove('hidden'));
             document.getElementById('admin-login-form').addEventListener('submit', handleAdminLogin);
-            
+
             document.getElementById('adminLogoutBtn').addEventListener('click', handleAdminLogout);
             document.getElementById('switchToUserFromAdmin').addEventListener('click', showUserView);
-            
+
             document.getElementById('add-employee-form').addEventListener('submit', handleAddEmployee);
             document.getElementById('employee-list-container').addEventListener('click', (e) => {
                 if (e.target.closest('.edit-employee-btn')) { openEmployeeEditModal(e.target.closest('.edit-employee-btn').dataset.id, e.target.closest('.edit-employee-btn').dataset.name); }
                 if (e.target.closest('.delete-employee-btn')) { handleDeleteEmployee(e.target.closest('.delete-employee-btn').dataset.id, e.target.closest('.delete-employee-btn').dataset.name); }
             });
             document.getElementById('edit-employee-form').addEventListener('submit', handleSaveEmployeeChanges);
-            
-            document.getElementById('searchInput').addEventListener('input', () => renderOrdersTable(allOrders));
+
+            document.getElementById('searchInput').addEventListener('input', async () => {
+                const docSnap = await getDoc(menuDocRef);
+                const menuData = docSnap.exists() ? docSnap.data() : { menu: [] };
+                const menuContext = getMenuContext(menuData);
+                renderOrdersTable(allOrders, menuContext);
+            });
             document.getElementById('generateReportBtn').addEventListener('click', generateAndPrintReport);
-            
+
             document.getElementById('ordersTableContainer').addEventListener('click', function(e) {
                 if (e.target.closest('.edit-order-btn')) { openOrderEditModal(e.target.closest('.edit-order-btn').dataset.id); }
                 if (e.target.closest('.delete-order-btn')) { deleteOrder(e.target.closest('.delete-order-btn').dataset.id, e.target.closest('.delete-order-btn').dataset.name); }
             });
             document.getElementById('edit-order-form').addEventListener('submit', saveOrderChanges);
-            
+
             document.getElementById('notifyWhatsAppBtn').addEventListener('click', handleWhatsAppNotification);
+
+            await validateForm();
         }
 
         main();


### PR DESCRIPTION
Implementa controle de visualização e edição de cardápio semanal

Funcionalidades:
- Funcionários podem visualizar o cardápio da semana anterior ou o futuro (após atualização do admin na quinta-feira) em modo somente leitura.
- Funcionários podem fazer pedidos apenas para o cardápio da semana vigente, antes de quinta-feira ou se o admin já atualizou.
- Após um pedido ser feito, o funcionário não pode mais alterá-lo para a semana vigente.
- Administradores podem atualizar o cardápio via upload de imagem (funcionalidade existente).
- Administradores podem editar o pedido de qualquer funcionário a qualquer momento.

Detalhes Técnicos:
- Introduzido o conceito de `menuContext` ('EDITABLE_CURRENT', 'VIEW_ONLY_PREVIOUS', 'ADMIN_EDIT') para controlar a lógica de exibição e interação.
- O `menuLastUpdated` (timestamp) é armazenado no documento do cardápio no Firestore.
- Pedidos agora armazenam o `menuTimestamp` para identificar a qual versão do cardápio pertencem.
- Funções `createMenuHTML`, `validateForm`, `loadAndDisplayMenu`, e `openOrderEditModal` foram ajustadas para respeitar o `menuContext` e o status do pedido do funcionário.
- Adicionados indicadores visuais (cores e mensagens) na `guidanceSection` para informar você sobre o estado do cardápio.